### PR TITLE
Cash-228 - Remove propertySetter annotation off BaseRestInstanceTypeResource

### DIFF
--- a/omod/src/main/java/org/openmrs/module/webservices/rest/resource/BaseRestInstanceTypeResource.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/resource/BaseRestInstanceTypeResource.java
@@ -2,7 +2,6 @@ package org.openmrs.module.webservices.rest.resource;
 
 import org.openmrs.module.openhmis.commons.api.entity.model.IInstanceAttributeType;
 import org.openmrs.module.openhmis.commons.api.entity.model.IInstanceType;
-import org.openmrs.module.webservices.rest.web.annotation.PropertySetter;
 import org.openmrs.module.webservices.rest.web.representation.RefRepresentation;
 import org.openmrs.module.webservices.rest.web.representation.Representation;
 import org.openmrs.module.webservices.rest.web.resource.impl.DelegatingResourceDescription;
@@ -39,7 +38,6 @@ public abstract class BaseRestInstanceTypeResource<
 		return description;
 	}
 
-	@PropertySetter("attributeTypes")
 	public void setAttributeTypes(E instance, List<TAttributeType> attributeTypes) {
 		if (instance.getAttributeTypes() == null) {
 			instance.setAttributeTypes(new ArrayList<TAttributeType>());


### PR DESCRIPTION
Remove the propertysetter annotation from BaseRestInstanceTypeResource class. This will ensure ONLY the sub-class' setAttributeTypes method (with the correct parameter types) is picked up.