### PR TITLE
Properly handle resources without services.

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<artifactId>openhmis.commons</artifactId>
 		<groupId>org.openmrs.module</groupId>
-		<version>3.1.0</version>
+		<version>3.1.1</version>
 	</parent>
 
 	<artifactId>openhmis.commons-api</artifactId>

--- a/api/src/main/java/org/openmrs/module/openhmis/commons/uiframework/UiConfigurationFactory.java
+++ b/api/src/main/java/org/openmrs/module/openhmis/commons/uiframework/UiConfigurationFactory.java
@@ -10,9 +10,8 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
 /**
- * Abstract functionality for registering a UIFramework 2.x module. This class
- * will ONLY load modules if UiFramework 2.x module is loaded. It replaces use
- * of openmrs annotations which do not check if UiFramework 2.x has been loaded.
+ * Abstract functionality for registering a UIFramework 2.x module. This class will ONLY load modules if UiFramework 2.x
+ * module is loaded. It replaces use of openmrs annotations which do not check if UiFramework 2.x has been loaded.
  */
 public abstract class UiConfigurationFactory implements BeanFactoryPostProcessor {
 
@@ -28,7 +27,7 @@ public abstract class UiConfigurationFactory implements BeanFactoryPostProcessor
 		try {
 			// load UiFramework's StandardModuleUiConfiguration class
 			Class cls = OpenmrsClassLoader.getInstance()
-					.loadClass("org.openmrs.ui.framework.StandardModuleUiConfiguration");
+			        .loadClass("org.openmrs.ui.framework.StandardModuleUiConfiguration");
 
 			// get spring's bean definition builder
 			BeanDefinitionBuilder builder = BeanDefinitionBuilder.rootBeanDefinition(cls);
@@ -37,13 +36,13 @@ public abstract class UiConfigurationFactory implements BeanFactoryPostProcessor
 			builder.addPropertyValue("moduleId", getModuleId());
 
 			// register bean
-			((DefaultListableBeanFactory) beanFactory).registerBeanDefinition(
-					getModuleId() + "StandardModuleUiConfiguration", builder.getBeanDefinition());
+			((DefaultListableBeanFactory)beanFactory).registerBeanDefinition(
+			    getModuleId() + "StandardModuleUiConfiguration", builder.getBeanDefinition());
 
 			log.info(getModuleId() + " successfully registered!");
 		} catch (ClassNotFoundException ex) {
 			log.info("StandardModuleUiConfiguration class not found. Unable to register " + getModuleId()
-					+ " UI 2.x module");
+			        + " UI 2.x module");
 		}
 	}
 }

--- a/omod/pom.xml
+++ b/omod/pom.xml
@@ -4,7 +4,7 @@
 	<parent>
 		<artifactId>openhmis.commons</artifactId>
 		<groupId>org.openmrs.module</groupId>
-		<version>3.1.0</version>
+		<version>3.1.1</version>
 	</parent>
 
 	<artifactId>openhmis.commons-omod</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<groupId>org.openmrs.module</groupId>
 	<artifactId>openhmis.commons</artifactId>
 	<packaging>pom</packaging>
-	<version>3.1.0</version>
+	<version>3.1.1</version>
 	<name>OpenHMIS Commons Module</name>
 	<description>Module that provides core functionality used by the OpenHMIS modules.</description>
 	<url>http://openhmis.github.com/</url>

--- a/tools/pom.xml
+++ b/tools/pom.xml
@@ -3,7 +3,7 @@
 	<parent>
 		<groupId>org.openmrs.module</groupId>
 		<artifactId>openhmis.commons</artifactId>
-		<version>3.1.0</version>
+		<version>3.1.1</version>
 	</parent>
 
 	<modelVersion>4.0.0</modelVersion>


### PR DESCRIPTION
    As of RESTWS v2.12 child resources will attempt to load from the database which causes problems when that resource does
        not have an associated service. The code will now take that into account and just return null rather than throw an
        exception
    core-48