### PR TITLE
Using Collection.isEmpty() to test for emptiness

### DIFF
--- a/api/src/main/java/org/openmrs/module/openhmis/commons/api/ProviderUtil.java
+++ b/api/src/main/java/org/openmrs/module/openhmis/commons/api/ProviderUtil.java
@@ -31,7 +31,7 @@ public class ProviderUtil {
 
 	public static Provider getCurrentProvider(ProviderService providerService) {
 		Collection<Provider> providers = providerService.getProvidersByPerson(Context.getAuthenticatedUser().getPerson());
-		if (providers.size() > 0) {
+		if (!providers.isEmpty()) {
 			return providers.iterator().next();
 		}
 

--- a/api/src/main/java/org/openmrs/module/openhmis/commons/api/entity/db/hibernate/HibernateRepository.java
+++ b/api/src/main/java/org/openmrs/module/openhmis/commons/api/entity/db/hibernate/HibernateRepository.java
@@ -77,7 +77,7 @@ public class HibernateRepository implements IHibernateRepository {
 		DbSession session = sessionFactory.getCurrentSession();
 		try {
 
-			if (collection != null && collection.size() > 0) {
+			if (collection != null && !collection.isEmpty()) {
 				for (OpenmrsObject obj : collection) {
 					session.saveOrUpdate(obj);
 				}
@@ -128,7 +128,7 @@ public class HibernateRepository implements IHibernateRepository {
 		try {
 			List<E> results = criteria.list();
 
-			if (results.size() > 0) {
+			if (!results.isEmpty()) {
 				result = results.get(0);
 			}
 		} catch (Exception ex) {

--- a/api/src/main/java/org/openmrs/module/openhmis/commons/api/entity/impl/BaseCustomizableEntityDataServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/openhmis/commons/api/entity/impl/BaseCustomizableEntityDataServiceImpl.java
@@ -35,7 +35,7 @@ public abstract class BaseCustomizableEntityDataServiceImpl<E extends BaseCustom
 		}
 
 		Collection attributes = entity.getAttributes();
-		if (attributes != null && attributes.size() > 0) {
+		if (attributes != null && !attributes.isEmpty()) {
 			result.addAll(attributes);
 		}
 

--- a/api/src/main/java/org/openmrs/module/openhmis/commons/api/entity/impl/BaseCustomizableMetadataDataServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/openhmis/commons/api/entity/impl/BaseCustomizableMetadataDataServiceImpl.java
@@ -35,7 +35,7 @@ public abstract class BaseCustomizableMetadataDataServiceImpl<E extends BaseCust
 		}
 
 		Collection attributes = entity.getAttributes();
-		if (attributes != null && attributes.size() > 0) {
+		if (attributes != null && !attributes.isEmpty()) {
 			result.addAll(attributes);
 		}
 

--- a/api/src/main/java/org/openmrs/module/openhmis/commons/api/entity/impl/BaseCustomizableObjectDataServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/openhmis/commons/api/entity/impl/BaseCustomizableObjectDataServiceImpl.java
@@ -39,7 +39,7 @@ public abstract class BaseCustomizableObjectDataServiceImpl<E extends BaseCustom
 		}
 
 		Collection attributes = entity.getAttributes();
-		if (attributes != null && attributes.size() > 0) {
+		if (attributes != null && !attributes.isEmpty()) {
 			result.addAll(attributes);
 		}
 

--- a/api/src/main/java/org/openmrs/module/openhmis/commons/api/entity/impl/BaseEntityDataServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/openhmis/commons/api/entity/impl/BaseEntityDataServiceImpl.java
@@ -62,7 +62,7 @@ public abstract class BaseEntityDataServiceImpl<E extends OpenmrsData>
 			}
 		});
 
-		if (updatedObjects.size() > 0) {
+		if (!updatedObjects.isEmpty()) {
 			return saveAll(entity, updatedObjects);
 		} else {
 			return save(entity);
@@ -97,7 +97,7 @@ public abstract class BaseEntityDataServiceImpl<E extends OpenmrsData>
 			}
 		});
 
-		if (updatedObjects.size() > 0) {
+		if (!updatedObjects.isEmpty()) {
 			return saveAll(entity, updatedObjects);
 		} else {
 			return save(entity);

--- a/api/src/main/java/org/openmrs/module/openhmis/commons/api/entity/impl/BaseMetadataDataServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/openhmis/commons/api/entity/impl/BaseMetadataDataServiceImpl.java
@@ -72,7 +72,7 @@ public abstract class BaseMetadataDataServiceImpl<E extends OpenmrsMetadata>
 				        setRetireProperties(metadata, reason, user, dateRetired);
 			        }
 		        });
-		if (updatedObjects.size() > 0) {
+		if (!updatedObjects.isEmpty()) {
 			return saveAll(entity, updatedObjects);
 		} else {
 			return save(entity);
@@ -114,7 +114,7 @@ public abstract class BaseMetadataDataServiceImpl<E extends OpenmrsMetadata>
 				        setUnretireProperties(metadata);
 			        }
 		        });
-		if (updatedObjects.size() > 0) {
+		if (!updatedObjects.isEmpty()) {
 			return saveAll(entity, updatedObjects);
 		} else {
 			return save(entity);

--- a/api/src/main/java/org/openmrs/module/openhmis/commons/api/entity/impl/BaseObjectDataServiceImpl.java
+++ b/api/src/main/java/org/openmrs/module/openhmis/commons/api/entity/impl/BaseObjectDataServiceImpl.java
@@ -274,7 +274,7 @@ public abstract class BaseObjectDataServiceImpl<E extends OpenmrsObject, P exten
 		List<T> updatedObjects = new ArrayList<T>();
 
 		Collection<? extends OpenmrsObject> relatedObjects = getRelatedObjects(entity);
-		if (relatedObjects != null && relatedObjects.size() > 0) {
+		if (relatedObjects != null && !relatedObjects.isEmpty()) {
 			for (OpenmrsObject object : relatedObjects) {
 				T data = Utility.as(clazz, object);
 				if (data != null) {

--- a/api/src/main/java/org/openmrs/module/openhmis/commons/api/util/SafeIdgenUtil.java
+++ b/api/src/main/java/org/openmrs/module/openhmis/commons/api/util/SafeIdgenUtil.java
@@ -52,7 +52,7 @@ public class SafeIdgenUtil {
 
 		IdentifierSourceService service = Context.getService(IdentifierSourceService.class);
 		List<IdentifierSource> sources = service.getAllIdentifierSources(false);
-		if (sources != null && sources.size() > 0) {
+		if (sources != null && !sources.isEmpty()) {
 			for (IdentifierSource source : sources) {
 				results.add(new SafeIdentifierSource(source.getId(), source.getUuid(), source.getName()));
 			}

--- a/api/src/test/java/org/openmrs/module/openhmis/commons/api/entity/IMetadataDataServiceTest.java
+++ b/api/src/test/java/org/openmrs/module/openhmis/commons/api/entity/IMetadataDataServiceTest.java
@@ -257,7 +257,7 @@ public abstract class IMetadataDataServiceTest<S extends IMetadataDataService<E>
 
 		// Search using the first four characters in the name
 		List<E> entities = service.getByNameFragment(entity.getName(), false);
-		Assert.assertTrue(entities.size() > 0);
+		Assert.assertTrue(!entities.isEmpty());
 
 		// Make sure the entity is in the results
 		E found = null;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1155 - “Collection.isEmpty() should be used to test for emptiness”. You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1155
Please let me know if you have any questions.
Ayman Abdelghany.