### PR TITLE
 Utility classes should not have public constructors

### DIFF
--- a/api/src/main/java/org/openmrs/module/openhmis/commons/api/ProviderUtil.java
+++ b/api/src/main/java/org/openmrs/module/openhmis/commons/api/ProviderUtil.java
@@ -23,7 +23,7 @@ import org.openmrs.api.context.Context;
  * Utility class for {@link org.openmrs.Provider}s.
  */
 public class ProviderUtil {
-	protected ProviderUtil() {}
+	private ProviderUtil() {}
 
 	public static Provider getCurrentProvider() {
 		return getCurrentProvider(Context.getProviderService());

--- a/api/src/main/java/org/openmrs/module/openhmis/commons/api/Utility.java
+++ b/api/src/main/java/org/openmrs/module/openhmis/commons/api/Utility.java
@@ -31,7 +31,7 @@ public class Utility {
 	private static final int DATE_TIME_TEXT_LENGTH = 16;
 	private static final int DATE_TIME_SECOND_TEXT_LENGTH = 19;
 
-	protected Utility() {}
+	private Utility() {}
 
 	/**
 	 * Returns the specified object as the specified class or returns null if the cast is not supported.

--- a/api/src/main/java/org/openmrs/module/openhmis/commons/api/util/IdgenUtil.java
+++ b/api/src/main/java/org/openmrs/module/openhmis/commons/api/util/IdgenUtil.java
@@ -14,7 +14,7 @@ import org.openmrs.module.idgen.service.IdentifierSourceService;
 public class IdgenUtil {
 	private static final Log LOG = LogFactory.getLog(IdgenUtil.class);
 
-	protected IdgenUtil() {}
+	private IdgenUtil() {}
 
 	/**
 	 * Gets the {@link org.openmrs.module.idgen.IdentifierSource} with the id in the specified global property.

--- a/api/src/main/java/org/openmrs/module/openhmis/commons/api/util/PrivilegeUtil.java
+++ b/api/src/main/java/org/openmrs/module/openhmis/commons/api/util/PrivilegeUtil.java
@@ -15,7 +15,7 @@ public class PrivilegeUtil {
 
 	private static final Log LOG = LogFactory.getLog(PrivilegeUtil.class);
 
-	protected PrivilegeUtil() {}
+	private PrivilegeUtil() {}
 
 	/**
 	 * Checks if the specified user has all of the comma separated privileges.

--- a/api/src/main/java/org/openmrs/module/openhmis/commons/api/util/SafeIdgenUtil.java
+++ b/api/src/main/java/org/openmrs/module/openhmis/commons/api/util/SafeIdgenUtil.java
@@ -25,7 +25,7 @@ import org.openmrs.module.openhmis.commons.api.entity.model.SafeIdentifierSource
  * Idgen Utility class that does not directly reference the idgen module.
  */
 public class SafeIdgenUtil {
-	protected SafeIdgenUtil() {}
+	private SafeIdgenUtil() {}
 
 	/**
 	 * Gets the identifier source information with the id in the specified global property.

--- a/api/src/main/java/org/openmrs/module/openhmis/commons/api/util/UrlUtil.java
+++ b/api/src/main/java/org/openmrs/module/openhmis/commons/api/util/UrlUtil.java
@@ -5,7 +5,7 @@ package org.openmrs.module.openhmis.commons.api.util;
  */
 public class UrlUtil {
 
-	protected UrlUtil() {}
+	private UrlUtil() {}
 
 	/**
 	 * Adds the '.form' ending to the specified page, if it does not already exist.

--- a/api/src/main/java/org/openmrs/module/openhmis/commons/attribute/AttributeUtil.java
+++ b/api/src/main/java/org/openmrs/module/openhmis/commons/attribute/AttributeUtil.java
@@ -26,7 +26,7 @@ import org.openmrs.util.OpenmrsClassLoader;
 public class AttributeUtil {
 	private static final Log LOG = LogFactory.getLog(AttributeUtil.class);
 
-	protected AttributeUtil() {}
+	private AttributeUtil() {}
 
 	/**
 	 * Attempts to create a new instance of the specified class and hydrate (deserialize) it using the specified string

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/resource/PagingUtil.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/resource/PagingUtil.java
@@ -20,7 +20,7 @@ import org.openmrs.module.webservices.rest.web.RequestContext;
  * Utility class for extracting paging information from a request
  */
 public class PagingUtil {
-	protected PagingUtil() {}
+	private PagingUtil() {}
 
 	public static PagingInfo getPagingInfoFromContext(RequestContext context) {
 		Integer page = (context.getStartIndex() / context.getLimit()) + 1;


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1118 - “Utility classes should not have public constructors ”. You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1118
Please let me know if you have any questions.
Ayman Abdelghany.