### PR TITLE
Refactor generic rest attribute code

### DIFF
--- a/omod/src/main/java/org/openmrs/module/webservices/rest/resource/BaseRestAttributeDataResource.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/resource/BaseRestAttributeDataResource.java
@@ -4,16 +4,11 @@ import org.openmrs.Concept;
 import org.openmrs.OpenmrsData;
 import org.openmrs.api.ConceptService;
 import org.openmrs.api.context.Context;
-import org.openmrs.module.openhmis.commons.api.entity.IMetadataDataService;
 import org.openmrs.module.openhmis.commons.api.entity.model.IAttribute;
 import org.openmrs.module.openhmis.commons.api.entity.model.IAttributeType;
-import org.openmrs.module.openhmis.commons.api.entity.model.ISimpleAttribute;
-import org.openmrs.module.webservices.rest.web.annotation.PropertyGetter;
-import org.openmrs.module.webservices.rest.web.annotation.PropertySetter;
 import org.openmrs.module.webservices.rest.web.representation.RefRepresentation;
 import org.openmrs.module.webservices.rest.web.representation.Representation;
 import org.openmrs.module.webservices.rest.web.resource.impl.DelegatingResourceDescription;
-import org.openmrs.module.webservices.rest.web.response.ObjectNotFoundException;
 
 // @formatter:off
 /**

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/resource/BaseRestAttributeDataResource.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/resource/BaseRestAttributeDataResource.java
@@ -38,8 +38,7 @@ public abstract class BaseRestAttributeDataResource<
 		return description;
 	}
 
-	@PropertyGetter("value")
-	public Object getPropertyValue(E instance) {
+	protected Object baseGetPropertyValue(E instance) {
 		if (instance.getAttributeType().getFormat().contains("Concept")) {
 			ConceptService service = Context.getService(ConceptService.class);
 			Concept concept = service.getConcept(instance.getValue());
@@ -50,8 +49,7 @@ public abstract class BaseRestAttributeDataResource<
 		}
 	}
 
-	@PropertySetter("attributeType")
-	public void setAttributeType(E instance, TAttributeType attributeType) {
+	protected void baseSetAttributeType(E instance, TAttributeType attributeType) {
 		instance.setAttributeType(attributeType);
 	}
 

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/resource/BaseRestAttributeMetadataResource.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/resource/BaseRestAttributeMetadataResource.java
@@ -4,15 +4,11 @@ import org.openmrs.Concept;
 import org.openmrs.OpenmrsMetadata;
 import org.openmrs.api.ConceptService;
 import org.openmrs.api.context.Context;
-import org.openmrs.module.openhmis.commons.api.entity.IMetadataDataService;
 import org.openmrs.module.openhmis.commons.api.entity.model.IAttribute;
 import org.openmrs.module.openhmis.commons.api.entity.model.IAttributeType;
-import org.openmrs.module.webservices.rest.web.annotation.PropertyGetter;
-import org.openmrs.module.webservices.rest.web.annotation.PropertySetter;
 import org.openmrs.module.webservices.rest.web.representation.RefRepresentation;
 import org.openmrs.module.webservices.rest.web.representation.Representation;
 import org.openmrs.module.webservices.rest.web.resource.impl.DelegatingResourceDescription;
-import org.openmrs.module.webservices.rest.web.response.ObjectNotFoundException;
 
 // @formatter:off
 /**

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/resource/BaseRestAttributeMetadataResource.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/resource/BaseRestAttributeMetadataResource.java
@@ -37,8 +37,7 @@ public abstract class BaseRestAttributeMetadataResource<
 		return description;
 	}
 
-	@PropertyGetter("value")
-	public Object getPropertyValue(E instance) {
+	protected Object baseGetPropertyValue(E instance) {
 		if (instance.getAttributeType().getFormat().contains("Concept")) {
 			ConceptService service = Context.getService(ConceptService.class);
 			Concept concept = service.getConcept(instance.getValue());
@@ -49,8 +48,7 @@ public abstract class BaseRestAttributeMetadataResource<
 		}
 	}
 
-	@PropertySetter("attributeType")
-	public void setAttributeType(E instance, TAttributeType attributeType) {
+	protected void baseSetAttributeType(E instance, TAttributeType attributeType) {
 		instance.setAttributeType(attributeType);
 	}
 

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/resource/BaseRestAttributeObjectResource.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/resource/BaseRestAttributeObjectResource.java
@@ -37,8 +37,7 @@ public abstract class BaseRestAttributeObjectResource<
 		return description;
 	}
 
-	@PropertyGetter("value")
-	public Object getValue(E instance) {
+	protected Object baseGetValue(E instance) {
 		if (instance.getAttributeType().getFormat().contains("Concept")) {
 			ConceptService service = Context.getService(ConceptService.class);
 			Concept concept = service.getConcept(instance.getValue());
@@ -49,8 +48,7 @@ public abstract class BaseRestAttributeObjectResource<
 		}
 	}
 
-	@PropertySetter("attributeType")
-	public void setAttributeType(E instance, TAttributeType attributeType) {
+	protected void baseSetAttributeType(E instance, TAttributeType attributeType) {
 		instance.setAttributeType(attributeType);
 	}
 

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/resource/BaseRestAttributeObjectResource.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/resource/BaseRestAttributeObjectResource.java
@@ -4,15 +4,11 @@ import org.openmrs.Concept;
 import org.openmrs.OpenmrsObject;
 import org.openmrs.api.ConceptService;
 import org.openmrs.api.context.Context;
-import org.openmrs.module.openhmis.commons.api.entity.IMetadataDataService;
 import org.openmrs.module.openhmis.commons.api.entity.model.IAttribute;
 import org.openmrs.module.openhmis.commons.api.entity.model.IAttributeType;
-import org.openmrs.module.webservices.rest.web.annotation.PropertyGetter;
-import org.openmrs.module.webservices.rest.web.annotation.PropertySetter;
 import org.openmrs.module.webservices.rest.web.representation.RefRepresentation;
 import org.openmrs.module.webservices.rest.web.representation.Representation;
 import org.openmrs.module.webservices.rest.web.resource.impl.DelegatingResourceDescription;
-import org.openmrs.module.webservices.rest.web.response.ObjectNotFoundException;
 
 // @formatter:off
 /**

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/resource/BaseRestCustomizableDataResource.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/resource/BaseRestCustomizableDataResource.java
@@ -46,8 +46,7 @@ public abstract class BaseRestCustomizableDataResource<
 		return description;
 	}
 
-	@PropertySetter("attributes")
-	public void setAttributes(E instance, List<TAttribute> attributes) {
+	protected void setAttributes(E instance, List<TAttribute> attributes) {
 		if (instance.getAttributes() == null) {
 			instance.setAttributes(new HashSet<TAttribute>());
 		}

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/resource/BaseRestCustomizableDataResource.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/resource/BaseRestCustomizableDataResource.java
@@ -16,7 +16,6 @@ package org.openmrs.module.webservices.rest.resource;
 import org.openmrs.OpenmrsData;
 import org.openmrs.module.openhmis.commons.api.entity.model.IAttribute;
 import org.openmrs.module.openhmis.commons.api.entity.model.ICustomizable;
-import org.openmrs.module.webservices.rest.web.annotation.PropertySetter;
 import org.openmrs.module.webservices.rest.web.representation.RefRepresentation;
 import org.openmrs.module.webservices.rest.web.representation.Representation;
 import org.openmrs.module.webservices.rest.web.resource.impl.DelegatingResourceDescription;
@@ -46,7 +45,7 @@ public abstract class BaseRestCustomizableDataResource<
 		return description;
 	}
 
-	protected void setAttributes(E instance, List<TAttribute> attributes) {
+	protected void baseSetAttributes(E instance, List<TAttribute> attributes) {
 		if (instance.getAttributes() == null) {
 			instance.setAttributes(new HashSet<TAttribute>());
 		}

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/resource/BaseRestCustomizableMetadataResource.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/resource/BaseRestCustomizableMetadataResource.java
@@ -16,7 +16,6 @@ package org.openmrs.module.webservices.rest.resource;
 import org.openmrs.OpenmrsMetadata;
 import org.openmrs.module.openhmis.commons.api.entity.model.IAttribute;
 import org.openmrs.module.openhmis.commons.api.entity.model.ICustomizable;
-import org.openmrs.module.webservices.rest.web.annotation.PropertySetter;
 import org.openmrs.module.webservices.rest.web.representation.RefRepresentation;
 import org.openmrs.module.webservices.rest.web.representation.Representation;
 import org.openmrs.module.webservices.rest.web.resource.impl.DelegatingResourceDescription;
@@ -46,7 +45,7 @@ public abstract class BaseRestCustomizableMetadataResource<
 		return description;
 	}
 
-	protected void setAttributes(E instance, List<TAttribute> attributes) {
+	protected void baseSetAttributes(E instance, List<TAttribute> attributes) {
 		if (instance.getAttributes() == null) {
 			instance.setAttributes(new HashSet<TAttribute>());
 		}

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/resource/BaseRestCustomizableMetadataResource.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/resource/BaseRestCustomizableMetadataResource.java
@@ -46,8 +46,7 @@ public abstract class BaseRestCustomizableMetadataResource<
 		return description;
 	}
 
-	@PropertySetter("attributes")
-	public void setAttributes(E instance, List<TAttribute> attributes) {
+	protected void setAttributes(E instance, List<TAttribute> attributes) {
 		if (instance.getAttributes() == null) {
 			instance.setAttributes(new HashSet<TAttribute>());
 		}

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/resource/BaseRestCustomizableObjectResource.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/resource/BaseRestCustomizableObjectResource.java
@@ -16,8 +16,6 @@ package org.openmrs.module.webservices.rest.resource;
 import org.openmrs.OpenmrsObject;
 import org.openmrs.module.openhmis.commons.api.entity.model.IAttribute;
 import org.openmrs.module.openhmis.commons.api.entity.model.ICustomizable;
-import org.openmrs.module.openhmis.commons.api.entity.model.ISimpleAttribute;
-import org.openmrs.module.webservices.rest.web.annotation.PropertySetter;
 import org.openmrs.module.webservices.rest.web.representation.RefRepresentation;
 import org.openmrs.module.webservices.rest.web.representation.Representation;
 import org.openmrs.module.webservices.rest.web.resource.impl.DelegatingResourceDescription;
@@ -47,7 +45,7 @@ public abstract class BaseRestCustomizableObjectResource<
 		return description;
 	}
 
-	protected void setAttributes(E instance, List<TAttribute> attributes) {
+	protected void baseSetAttributes(E instance, List<TAttribute> attributes) {
 		if (instance.getAttributes() == null) {
 			instance.setAttributes(new HashSet<TAttribute>());
 		}

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/resource/BaseRestCustomizableObjectResource.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/resource/BaseRestCustomizableObjectResource.java
@@ -47,8 +47,7 @@ public abstract class BaseRestCustomizableObjectResource<
 		return description;
 	}
 
-	@PropertySetter("attributes")
-	public void setAttributes(E instance, List<TAttribute> attributes) {
+	protected void setAttributes(E instance, List<TAttribute> attributes) {
 		if (instance.getAttributes() == null) {
 			instance.setAttributes(new HashSet<TAttribute>());
 		}

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/resource/BaseRestInstanceCustomizableDataResource.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/resource/BaseRestInstanceCustomizableDataResource.java
@@ -1,13 +1,9 @@
 package org.openmrs.module.webservices.rest.resource;
 
 import org.openmrs.OpenmrsData;
-import org.openmrs.module.openhmis.commons.api.entity.model.IInstanceCustomizable;
 import org.openmrs.module.openhmis.commons.api.entity.model.IInstanceAttribute;
+import org.openmrs.module.openhmis.commons.api.entity.model.IInstanceCustomizable;
 import org.openmrs.module.openhmis.commons.api.entity.model.IInstanceType;
-import org.openmrs.module.webservices.rest.web.annotation.PropertySetter;
-import org.openmrs.module.webservices.rest.web.representation.RefRepresentation;
-import org.openmrs.module.webservices.rest.web.representation.Representation;
-import org.openmrs.module.webservices.rest.web.resource.impl.DelegatingResourceDescription;
 
 // @formatter:off
 /**

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/resource/BaseRestInstanceCustomizableMetadataResource.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/resource/BaseRestInstanceCustomizableMetadataResource.java
@@ -1,13 +1,9 @@
 package org.openmrs.module.webservices.rest.resource;
 
 import org.openmrs.OpenmrsMetadata;
-import org.openmrs.module.openhmis.commons.api.entity.model.IInstanceCustomizable;
 import org.openmrs.module.openhmis.commons.api.entity.model.IInstanceAttribute;
+import org.openmrs.module.openhmis.commons.api.entity.model.IInstanceCustomizable;
 import org.openmrs.module.openhmis.commons.api.entity.model.IInstanceType;
-import org.openmrs.module.webservices.rest.web.annotation.PropertySetter;
-import org.openmrs.module.webservices.rest.web.representation.RefRepresentation;
-import org.openmrs.module.webservices.rest.web.representation.Representation;
-import org.openmrs.module.webservices.rest.web.resource.impl.DelegatingResourceDescription;
 
 // @formatter:off
 /**

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/resource/BaseRestInstanceCustomizableObjectResource.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/resource/BaseRestInstanceCustomizableObjectResource.java
@@ -1,13 +1,9 @@
 package org.openmrs.module.webservices.rest.resource;
 
 import org.openmrs.OpenmrsObject;
-import org.openmrs.module.openhmis.commons.api.entity.model.IInstanceCustomizable;
 import org.openmrs.module.openhmis.commons.api.entity.model.IInstanceAttribute;
+import org.openmrs.module.openhmis.commons.api.entity.model.IInstanceCustomizable;
 import org.openmrs.module.openhmis.commons.api.entity.model.IInstanceType;
-import org.openmrs.module.webservices.rest.web.annotation.PropertySetter;
-import org.openmrs.module.webservices.rest.web.representation.RefRepresentation;
-import org.openmrs.module.webservices.rest.web.representation.Representation;
-import org.openmrs.module.webservices.rest.web.resource.impl.DelegatingResourceDescription;
 
 // @formatter:off
 /**

--- a/omod/src/main/java/org/openmrs/module/webservices/rest/resource/BaseRestInstanceTypeResource.java
+++ b/omod/src/main/java/org/openmrs/module/webservices/rest/resource/BaseRestInstanceTypeResource.java
@@ -38,7 +38,7 @@ public abstract class BaseRestInstanceTypeResource<
 		return description;
 	}
 
-	public void setAttributeTypesBase(E instance, List<TAttributeType> attributeTypes) {
+	protected void baseSetAttributeTypes(E instance, List<TAttributeType> attributeTypes) {
 		if (instance.getAttributeTypes() == null) {
 			instance.setAttributeTypes(new ArrayList<TAttributeType>());
 		}


### PR DESCRIPTION
    Removed the property setter/getter annotations from generic methods
    Renamed base methods so that name collisions won't happen
    core-99